### PR TITLE
Fix blog post title overlap with header

### DIFF
--- a/templates/blog_post.html
+++ b/templates/blog_post.html
@@ -165,21 +165,17 @@
 </nav>
 
 <!-- Featured Image Header -->
-<div class="relative bg-gradient-to-br from-blue-900 via-blue-800 to-cyan-700 {% if post.featured_image %}h-96{% else %}h-64{% endif %} overflow-hidden">
+<header class="relative overflow-hidden bg-gradient-to-br from-blue-900 via-blue-800 to-cyan-700 {% if post.featured_image %}h-[28rem]{% else %}h-72{% endif %}">
     {% if post.featured_image %}
     <img 
         src="{{ url_for('static', filename=post.featured_image) }}" 
         alt="{{ post.title }}"
-        class="absolute inset-0 w-full h-full object-cover opacity-40"
+        class="absolute inset-0 w-full h-full object-cover opacity-50"
     >
     {% endif %}
-    <div class="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent"></div>
-</div>
-
-<!-- Article Header -->
-<article class="bg-white">
-    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="-mt-32 relative z-10">
+    <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/40 to-transparent"></div>
+    <div class="relative h-full flex items-end">
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12 w-full">
             <!-- Category Badge -->
             <div class="mb-4">
                 <span class="inline-block px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-full shadow-lg">
@@ -188,12 +184,12 @@
             </div>
             
             <!-- Title -->
-            <h1 class="text-4xl md:text-5xl font-extrabold text-white mb-6 leading-tight">
+            <h1 class="text-4xl sm:text-5xl font-extrabold text-white mb-6 leading-tight drop-shadow-lg">
                 {{ post.title }}
             </h1>
             
             <!-- Meta Information -->
-            <div class="flex flex-wrap items-center gap-4 text-blue-100 mb-8">
+            <div class="flex flex-wrap items-center gap-4 text-blue-100">
                 <div class="flex items-center">
                     <i class="far fa-user-circle mr-2"></i>
                     <span>{{ post.author if post.author else 'Fin Finder Team' }}</span>
@@ -208,7 +204,12 @@
                 </div>
             </div>
         </div>
-        
+    </div>
+</header>
+
+<!-- Article Body -->
+<article class="bg-white">
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <!-- Article Content -->
         <div class="py-12">
             <div class="blog-content prose prose-lg max-w-none">

--- a/templates/blog_post.html
+++ b/templates/blog_post.html
@@ -173,34 +173,36 @@
         class="absolute inset-0 w-full h-full object-cover opacity-50"
     >
     {% endif %}
-    <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/40 to-transparent"></div>
-    <div class="relative h-full flex items-end">
-        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12 w-full">
-            <!-- Category Badge -->
-            <div class="mb-4">
-                <span class="inline-block px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-full shadow-lg">
-                    {{ post.category|title }}
-                </span>
-            </div>
-            
-            <!-- Title -->
-            <h1 class="text-4xl sm:text-5xl font-extrabold text-white mb-6 leading-tight drop-shadow-lg">
-                {{ post.title }}
-            </h1>
-            
-            <!-- Meta Information -->
-            <div class="flex flex-wrap items-center gap-4 text-blue-100">
-                <div class="flex items-center">
-                    <i class="far fa-user-circle mr-2"></i>
-                    <span>{{ post.author if post.author else 'Fin Finder Team' }}</span>
+    <div class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent"></div>
+    <div class="relative h-full flex items-end py-10 sm:py-12">
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 w-full">
+            <div class="bg-white/95 backdrop-blur-lg rounded-2xl shadow-2xl p-6 sm:p-8">
+                <!-- Category Badge -->
+                <div class="mb-4">
+                    <span class="inline-block px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-full shadow-lg">
+                        {{ post.category|title }}
+                    </span>
                 </div>
-                <div class="flex items-center">
-                    <i class="far fa-calendar mr-2"></i>
-                    <span>{{ post.date }}</span>
-                </div>
-                <div class="flex items-center">
-                    <i class="far fa-clock mr-2"></i>
-                    <span>{{ post.read_time }} min read</span>
+                
+                <!-- Title -->
+                <h1 class="text-3xl sm:text-4xl md:text-5xl font-extrabold text-gray-900 mb-6 leading-tight">
+                    {{ post.title }}
+                </h1>
+                
+                <!-- Meta Information -->
+                <div class="flex flex-wrap items-center gap-4 text-gray-600">
+                    <div class="flex items-center">
+                        <i class="far fa-user-circle mr-2 text-blue-600"></i>
+                        <span>{{ post.author if post.author else 'Fin Finder Team' }}</span>
+                    </div>
+                    <div class="flex items-center">
+                        <i class="far fa-calendar mr-2 text-blue-600"></i>
+                        <span>{{ post.date }}</span>
+                    </div>
+                    <div class="flex items-center">
+                        <i class="far fa-clock mr-2 text-blue-600"></i>
+                        <span>{{ post.read_time }} min read</span>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Moves blog post titles into the hero header with a gradient overlay and drop shadow to prevent overlap and improve readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-00770ff6-b6e4-4e01-a41f-163adb6746bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-00770ff6-b6e4-4e01-a41f-163adb6746bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

